### PR TITLE
Chore: Add missing doc blocks to hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.0.1
 
-- Add LICENSE to package.
-- Add CHANGELOG.md to package.
+- Docs: Add LICENSE to package.
+- Docs: Add CHANGELOG.md to package.
+- Docs: Add missing doc blocks.
 
 ## 1.0.0 (Initial Release)
 

--- a/hooks/useBlur/index.tsx
+++ b/hooks/useBlur/index.tsx
@@ -17,6 +17,15 @@ const useBlur = (): BlurType => {
   const [isBlurred, setIsBlurred] = useState(false);
 
   useEffect(() => {
+    /**
+     * Handles clicks outside the referenced element.
+     *
+     * If the click target is outside the element,
+     * update the blurred state.
+     *
+     * @param {MouseEvent} e - The mouse event triggered when the document is clicked.
+     * @returns {void}
+     */
     const handleClickOutside = (e: MouseEvent): void => {
       const el = ref.current;
       if (el && !el.contains(e.target as Node) && !isBlurred) {
@@ -24,6 +33,13 @@ const useBlur = (): BlurType => {
       }
     };
 
+    /**
+     * Handles the focusin event by checking
+     * if the focused element is within the referenced element.
+     *
+     * @param {FocusEvent} e - The focus event triggered when an element receives focus.
+     * @returns {void}
+     */
     const handleFocusIn = (e: FocusEvent): void => {
       const el = ref.current;
       if (el && el.contains(e.target as Node)) {

--- a/hooks/useLocalStorage/index.tsx
+++ b/hooks/useLocalStorage/index.tsx
@@ -18,6 +18,17 @@ const useLocalStorage = (key: string): any => {
     JSON.stringify(localStorage.getItem(key))
   );
 
+  /**
+   * Handles the `storage` event triggered when a
+   * change is made to localStorage.
+   *
+   * If the changed key matches the specified key,
+   * update the stored item state only if the value has
+   * actually changed.
+   *
+   * @param {StorageEvent} e - The storage event triggered by changes to localStorage.
+   * @returns {void}
+   */
   const handleSetItemChange = useCallback(
     (e: StorageEvent) => {
       if (e.key !== key) {

--- a/hooks/useSelectedText/index.tsx
+++ b/hooks/useSelectedText/index.tsx
@@ -12,28 +12,38 @@ import { useEffect, useState, useCallback } from 'react';
 const useSelectedText = (targetRef?: React.RefObject<HTMLElement>): string => {
   const [selectedText, setSelectedText] = useState('');
 
+  /**
+   * Determines whether the current text selection
+   * is entirely within the target element.
+   *
+   * If the selection starts and ends within the target element;
+   * return `true`, otherwise, `false`.
+   *
+   * @returns {boolean}
+   */
   const isSelectionInTarget = useCallback((): boolean => {
     const selection = document.getSelection() as Selection | null;
 
-    if ( ! selection?.rangeCount || ! targetRef?.current ) {
+    if (!selection?.rangeCount || !targetRef?.current) {
       return false;
     }
 
-    const range: Range = selection.getRangeAt( 0 );
+    const range: Range = selection.getRangeAt(0);
 
     return (
-      targetRef.current.contains( range.startContainer ) &&
-      targetRef.current.contains( range.endContainer )
+      targetRef.current.contains(range.startContainer) &&
+      targetRef.current.contains(range.endContainer)
     );
   }, [targetRef]);
 
   /**
-   * On Selection.
+   * Handles text selection logic.
    *
-   * Get the selected text range and
-   * populate the state.
+   * Grabs the currently selected text and updates
+   * state based on whether the selection is within
+   * the target element.
    *
-   * @return {void}
+   * @returns {void}
    */
   const handleSelection = useCallback((): void => {
     const selectedString: string = document.getSelection()?.toString() || '';
@@ -55,6 +65,6 @@ const useSelectedText = (targetRef?: React.RefObject<HTMLElement>): string => {
   }, [handleSelection]);
 
   return selectedText;
-}
+};
 
 export default useSelectedText;


### PR DESCRIPTION
This PR resolves [issue](https://github.com/badasswp/rooks/issues/1).

## Description / Background Context

This PR adds missing doc blocks to hooks.

## Testing Instructions

1. Pull PR to local.
2. Observe that missing doc blocks have now been added.